### PR TITLE
Add vagrant user to docker group

### DIFF
--- a/vagrant/scripts/configure_rancher.sh
+++ b/vagrant/scripts/configure_rancher.sh
@@ -165,6 +165,7 @@ function install_docker() {
     elif [ `command -v wget` ]; then
       wget -qO- https://releases.rancher.com/install-docker/${docker_version}.sh | sh
     fi
+    usermod -aG docker vagrant
   else
     echo "Skipping Docker install."
   fi


### PR DESCRIPTION
This allows users to `vagrant ssh` in and run docker commands straight away, without having to `sudo`
(#5 and this are possibly mutually exclusive)