### PR TITLE
use latest rancher version that is available on dockerhub

### DIFF
--- a/vagrant/config.yaml
+++ b/vagrant/config.yaml
@@ -1,5 +1,5 @@
 default_password: admin
-rancher_version: v2.2.4
+rancher_version: v2.2.3
 cluster_name: rodeo
 rodeo: true
 docker_version:


### PR DESCRIPTION
Rancher version tag `v2.2.4` is not available on dockerhub