### PR TITLE
Bump deprecated beta ingress API version

### DIFF
--- a/charts/rancher-demo/Chart.yaml
+++ b/charts/rancher-demo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.0.6
 description: Rancher demo application, web UI showing scale of containers
 name: rancher-demo
-version: 2.1.6
+version: 2.1.7
 icon: https://rancher.com/img/brand-guidelines/assets/logos/png/color/rancher-logo-stacked-color.png
 maintainers:
   - name: Rancher

--- a/charts/rancher-demo/templates/ingress.yaml
+++ b/charts/rancher-demo/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "rancher-demo.fullname" . -}}
 {{- $ingressPaths := .Values.ingress.paths -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -29,7 +29,11 @@ spec:
     - host: {{ .Values.ingress.host | quote }}
       http:
         paths:
-        - backend:
-            serviceName: {{ $fullName }}
-            servicePort: http
+        - pathType: Prefix
+          path: "/"
+          backend:
+            service:
+              name: {{ $fullName }}
+              port:
+                name: http
 {{- end }}


### PR DESCRIPTION
Fix: Demo chart fails to install on K8s 1.22+